### PR TITLE
Fix accessibility typo in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -39,7 +39,7 @@
                 <li><a href="{{ anchor.fraud_waste_abuse_url }}" title="Report fraud, waste, or abuse to the Office of the Inspector General">Report fraud, waste, or abuse to the Office of the Inspector General</a></li>
                 <li><a href="{{ anchor.foia_request_url }}" title="Submit a Freedom of Information Act (FOIA) request">Submit a Freedom of Information Act (FOIA) request</a></li>
                 <li><a href="{{ anchor.budget_performance_url }}" title="View budget and performance reports">View budget and performance reports</a></li>
-                <li><a href="{{ anchor.accessibility_url }}" title="View accessiblity statement">View accessiblity statement</a></li>
+                <li><a href="{{ anchor.accessibility_url }}" title="View accessibility statement">View accessibility statement</a></li>
                 <li><a href="{{ anchor.no_fear_act_url }}" title="View No FEAR Act data">View No FEAR Act data</a></li>
               </ul>
             </div>


### PR DESCRIPTION
The footer-anchor template had a typo. Going through and trying to find all the ports. 